### PR TITLE
WIP: add debian buster support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,7 @@ galaxy_info:
       - trusty
   - name: Debian
     versions:
+      - buster
       - stretch
       - jessie
   galaxy_tags:

--- a/tasks/packages-debian-buster.yml
+++ b/tasks/packages-debian-buster.yml
@@ -1,0 +1,36 @@
+---
+
+- name: install dependencies
+  apt:
+    name: "{{ packages }}"
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600
+  vars:
+    packages:
+      - libsodium23
+      - libltdl7
+      - libssl1.1
+      - libicu63 
+      - libxml2
+      - libbz2-1.0
+      - libcurl3-gnutls
+      - libwebp6
+      - libpng16-16
+      - libfreetype6
+      - libmcrypt4
+      - libedit2
+      - libreadline7
+      - libxslt1.1
+      - libjpeg62-turbo
+      - libzip4
+      - libmagickwand-6.q16-6 
+      - libhiredis0.14 
+      - libmemcached11
+      - libmemcachedutil2
+      - libc-client2007e
+      - libkrb5-3
+      - libgmp10
+      - libgeoip1
+      - libgpgme11
+  become: yes


### PR DESCRIPTION
upgraded packages:

libcurl3 (OpenSSL flavour) ->  libcurl3-gnutls (GnuTLS flavour) 
libicu57 -> libicu63
libmagickwand-6.q16-3 -> libmagickwand-6.q16-6
libhiredis0.13 -> libhiredis0.14